### PR TITLE
Fix for uncentered BoundingBoxes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["graphics", "visualization"]
 readme = "README.md"
 
 [dependencies]
-delaunator = { path = "../delaunator-rs", version = "0.2.0" }
+delaunator = { version = "~0.2" }
+approx = { version = "~0.4" }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/src/cell_builder.rs
+++ b/src/cell_builder.rs
@@ -77,8 +77,13 @@ impl CellBuilder {
         // the vertex is the circumcenter of the triangle of edge a->b
         // the vertex is on the a->b bisector line, thus we can take midpoint of a->b and vertex for the orthogonal projection
         let edge_midpoint = Point { x: (site_a.x + site_b.x) / 2.0, y: (site_a.y + site_b.y) / 2.0 };
+        
         // clockwise rotation 90 degree from edge direction
-        let orthogonal = Point { x: site_b.y - site_a.y, y: site_a.x - site_b.x };
+        let mut orthogonal = Point { x: site_b.y - site_a.y, y: site_a.x - site_b.x };
+        // normalizing the orthogonal vector
+        let ortho_length = (orthogonal.x * orthogonal.x + orthogonal.y * orthogonal.y).sqrt();
+        orthogonal.x = orthogonal.x * (1. / ortho_length);
+        orthogonal.y = orthogonal.y * (1. / ortho_length);
 
         let projected = Point { x: edge_midpoint.x + (scale * orthogonal.x), y: edge_midpoint.y + (scale * orthogonal.y) };
         let index = self.vertices.len();
@@ -94,7 +99,7 @@ impl CellBuilder {
         // Add this extended vertex to the cell, and the previous cell extended vertex as well
         // Thus closing the cell. When clip logic runs for this cell, it will clip the extensions as needed
         // Set a extension scale to be more than the bounding box diagonal, to make sure we get nice clipped corners
-        let scale = 2.0 * self.bounding_box.width() * self.bounding_box.height();
+        let scale = self.bounding_box.width() + self.bounding_box.height();
 
         // handle first
         let &last_site = hull_sites.last().expect("");

--- a/src/cell_builder.rs
+++ b/src/cell_builder.rs
@@ -1010,13 +1010,13 @@ mod test {
     #[test]
     fn extend_and_close_hull_test() {
         let mut builder = new_builder(vec![
-            Point { x: 0.5, y: 0.625 }, // vertex to be extended
+            Point { x: -0.5, y: -0.25 }, // vertex to be extended
         ]);
         builder.calculate_corners();
         let sites = vec![
-            Point { x: 1.0, y: 1.0 },
-            Point { x: 0.0, y: 1.0 },
-            Point { x: 0.5, y: 0.0 },
+            Point { x: -0.5, y: 1.0 },
+            Point { x: -1.5, y: -1.0 },
+            Point { x: 0.5, y: -1.0 },
         ];
         assert_eq!(builder.vertices[0], utils::cicumcenter(&sites[0], &sites[1], &sites[2]), "I got the circumcenter wrong.");
         let hull_sites = (0..sites.len()).collect();
@@ -1028,21 +1028,21 @@ mod test {
         builder.extend_and_close_hull(&sites, &hull_sites, &mut cells);
 
         assert_cell_vertex_without_bounds(&builder, &cells[0], "First cell", vec![
-            Point { x: 0.5, y: 0.625 },
-            Point { x: 32.75, y: -15.5 },
-            Point { x: 0.5, y: 33.0 },
+            Point { x: -0.5, y: -0.25 },
+            Point { x: 7.155417527999327, y: 3.5777087639996634 },
+            Point { x: -8.155417527999326, y: 3.5777087639996634 },
         ]);
 
         assert_cell_vertex_without_bounds(&builder, &cells[1], "Second cell", vec![
-            Point { x: 0.5, y: 0.625 },
-            Point { x: 0.5, y: 33.0 },
-            Point { x: -31.75, y: -15.5 },
+            Point { x: -0.5, y: -0.25 },
+            Point { x: -8.155417527999326, y: 3.5777087639996634 },
+            Point { x: -0.5, y: -9.0 },
         ]);
 
         assert_cell_vertex_without_bounds(&builder, &cells[2], "Third cell", vec![
-            Point { x: 0.5, y: 0.625 },
-            Point { x: -31.75, y: -15.5 },
-            Point { x: 32.75, y: -15.5 },
+            Point { x: -0.5, y: -0.25 },
+            Point { x: -0.5, y: -9.0 },
+            Point { x: 7.155417527999327, y: 3.5777087639996634 },
         ]);
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -231,7 +231,7 @@ mod test {
             [0.2, -0.5],
             [0.3, -0.5],
         */
-        // need to find a way to remove delauney neighbors for whose voronoi edges were clipped out
+        // need to find a way to remove delauney neighbors whose voronoi edges were clipped out
         // comparing edge is one way, comparing circumcenters is another https://github.com/d3/d3-delaunay/pull/98/files
         let sites = vec![Point { x: -1.0, y: -1.0 }, Point { x: 0.0, y: -1.0 }, Point { x: -0.45, y: -0.95 }];
         let v = VoronoiBuilder::default()
@@ -283,7 +283,7 @@ mod test {
         assert_eq!(Some(0), path.next());
         assert_eq!(Some(1), path.next());
         // this fails because the point 13 is a neighbor of 1; this is technically true if we expand the bounding box to a large value
-        // 13 an 1 share an voronoi edge, but that edge is clipped by the bounding box
+        // 13 and 1 share a voronoi edge, but that edge is clipped by the bounding box
         assert_eq!(Some(3), path.next());
         assert_eq!(Some(5), path.next());
         assert_eq!(Some(8), path.next());


### PR DESCRIPTION
Supposedly fixes #2 

This commit changes the algorithm to not rely on mirrored coordinates, instead calculating `left` and `bottom` from the `BoundingBox` and checking for coordinates to be in range `bottom <= y <= top` and `left <= x <= right`. I chose not to rely on `un-shift -> voronoi -> re-shift`, since this could cause confusion for users.

---

The new output looks okay at first glance, but the `BoundingBox` Corners (e.g. top-left Voronoi-Diagram, upper right corner) are still a little broken. Haven't figured out why, yet.
![Voronoi_fix__corners_broken](https://user-images.githubusercontent.com/29286474/105499144-55a12600-5cc1-11eb-87f0-d4fd133507a7.png)

---

Benchmark Comparison "large_input_benchmark":

||100.000|1.000.000|5.000.000|10.000.000|
|---|---|---|---|---|
|Fix|28.814 ms|412.98 ms|2.4891 s|5.3512 s|
|Master|29.228 ms|418.78 ms|2.4628 s|5.3161 s|
