### PR TITLE
add Clone to vertices iter

### DIFF
--- a/src/voronoi_cell.rs
+++ b/src/voronoi_cell.rs
@@ -67,7 +67,7 @@ impl<'v> VoronoiCell<'v> {
     /// Vertices are returned in sequential counter-clockwise order.
     /// Please see [Self::iter_triangles] and [Voronoi::vertices] for additional details regarding hull closing and clipping effects on vertices.
     #[inline]
-    pub fn iter_vertices(&self) -> impl Iterator<Item = &Point> {
+    pub fn iter_vertices(&self) -> impl Iterator<Item = &Point> + Clone {
         self.iter_triangles().map(move |t| &self.voronoi.circumcenters[t])
     }
 


### PR DESCRIPTION
Hi,

I was trying to use `.cycle()` on the vertices iterator, and noticed it didn't have Clone.
Being able to use `cycle` is useful for computing the area of simple polygons, e.g.
```
cell.iter_vertices()
          .cycle()
          .take(cell.iter_vertices().count()+1)
          .tuple_windows() // from Itertools
          .map(|(a,b)| a.x*b.y - b.x*a.y)
          .sum::<f64>()
          .abs()
```